### PR TITLE
Arreglado un error al obtener el tiempo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Doxyfile
 TimeElapsed.cfg
 TimeElapsed.tag
 *.tag
+html/

--- a/TimeElapsed.cpp
+++ b/TimeElapsed.cpp
@@ -9,8 +9,8 @@
  * transcurrido y llamar a la función **getTimeElapsed()** cuando se quiera obtener una
  * cadena de tiempo con el citado tiempo.
  * 
- * @section author Author
- * - Created by Daniel Calvo 2020
+ * @author Daniel Calvo Gonzalez
+ *
  */
 #include <Arduino.h>
 #include "TimeElapsed.h"
@@ -36,6 +36,7 @@ TimeElapsed::TimeElapsed(byte days, byte hours, byte minutes, byte seconds) {
   * @return el número de segundos transcurridos
   */
 byte TimeElapsed::getSeconds() {
+  loopTimeElapsed();
   return _seconds;
 }
 
@@ -45,6 +46,7 @@ byte TimeElapsed::getSeconds() {
   * @return el número de minutos transcurridos
   */
 byte TimeElapsed::getMinutes() {
+  loopTimeElapsed();
   return _minutes;
 }
 
@@ -54,6 +56,7 @@ byte TimeElapsed::getMinutes() {
   * @return el número de horas transcurridas
   */
 byte TimeElapsed::getHours() {
+  loopTimeElapsed();
   return _hours;
 }
 
@@ -63,6 +66,7 @@ byte TimeElapsed::getHours() {
   * @return el número de dias transcurridos
   */
 byte TimeElapsed::getDays() {
+  loopTimeElapsed();
   return _days;
 }
 

--- a/TimeElapsed.h
+++ b/TimeElapsed.h
@@ -1,6 +1,8 @@
 /**
  * @file timeElapsed.h
  * 
+ * @author Daniel Calvo
+ *
  */
 #ifndef TIMEELAPSED_H
 #define TIMEELAPSED_H
@@ -12,7 +14,9 @@
 #define MAX_LEN_TIMEELAPSED 13
 
 /**
- * Clase que contiene la información necesaria para un control del tiempo transcurrido.
+ * @brief Clase para el control del tiempo transcurrido.
+ *
+ * Contiene los miembros y funciones necesarias para un control del tiempo transcurrido.
  * 
  */
 class TimeElapsed {


### PR DESCRIPTION
Las funciones que obtienen cada una de las partes de la hora, no actualizaban el contador de tiempo transcurrido